### PR TITLE
feat (frontend CRUD): Add furniture to the correct room

### DIFF
--- a/src/BudgetView/containers/BudgetView.js
+++ b/src/BudgetView/containers/BudgetView.js
@@ -15,7 +15,6 @@ class BudgetView extends Component {
   render() {
     return(
       <div>
-        <BudgetTable budget={this.props.budget} rooms={this.props.rooms}/>
         <BudgetGraph rooms={this.props.rooms}/>
       </div>
     );

--- a/src/cardList/components/AddFurnitureForm.js
+++ b/src/cardList/components/AddFurnitureForm.js
@@ -1,32 +1,42 @@
-import React,{ Component } from 'react';
-import {Button, Input, Col, Row} from 'react-materialize';
+import React, { Component } from 'react';
+import {Button, Input, Row} from 'react-materialize';
 import DatePicker from 'material-ui/DatePicker';
 import { reduxForm } from 'redux-form';
 import { connect} from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { addFurniture } from '../../furniture/actions/furniture.action';
 
 class AddFurnitureForm extends Component {
   render() {
-    console.log('[AddFurnitureForm form] roomSelected: ', this.props.roomSelected);
+    const { fields: { itemName, price, description, url, deliveryDate, roomSelected }, handleSubmit } = this.props;
 
     return (
-      <div>
+      <form onSubmit={ handleSubmit(this.props.addFurniture.bind(null, this.props.roomSelected)) }>
         <Row>
-          <Input s={6} placeholder='Item'/><Input s={6} placeholder='Price'/>
+          <Input s={6} placeholder='Item'{ ...itemName } />
+          <Input s={6} placeholder='Price'{ ...price } />
         </Row>
         <Row>
-          <Input s={6} placeholder='Description'/><Input s={6} placeholder='URL'/>
+          <Input s={6} placeholder='Description'{ ...description } />
+          <Input s={6} placeholder='URL'{ ...url } />
         </Row>
         <Row>
-          <Input s={6} placeholder='Delivery Date' label='Date' />
+          <Input s={6} placeholder='Delivery Date' label='Date' { ...deliveryDate } />
         </Row>
-        </div>
-      )
+        <Button type="submit">Submit</Button>
+      </form>
+    )
   }
 }
 
-function mapStateToProps({ roomSelected }) {
-  return { roomSelected };
-}
+export default reduxForm({
+  form: 'AddFurnitureForm',
+  fields: ['itemName', 'price', 'description', 'url', 'deliveryDate', 'roomSelected']
+}, state => ({ roomSelected: state.roomSelected }), {addFurniture})(AddFurnitureForm);
 
-export default connect(mapStateToProps)(AddFurnitureForm);
+
+//function mapStateToProps({ roomSelected }) {
+//  return { roomSelected };
+//}
+//
+//export default connect(mapStateToProps)(AddFurnitureForm);

--- a/src/cardList/components/AddRoomForm.js
+++ b/src/cardList/components/AddRoomForm.js
@@ -6,10 +6,9 @@ import { bindActionCreators } from 'redux';
 import { addRoom } from '../../rooms/actions/rooms.action'
 
 class AddRoomForm extends Component {
-
   render() {
-    
     const { fields: { roomName } , handleSubmit } = this.props;
+
     return (
       <form onSubmit = { handleSubmit(this.props.addRoom) } >
         <Input type="text" placeholder="Room Name" s={12} label="Room Name" { ...roomName } />

--- a/src/furniture/actions/furniture.action.js
+++ b/src/furniture/actions/furniture.action.js
@@ -4,11 +4,11 @@ export const UPDATE_FURNITURE = 'UPDATE_FURNITURE';
 
 // NOTE: Many corresponding reducers are in rooms.reducer, not in the furniture directory
 
-export function addFurniture(furnitureName, roomName) {
+export function addFurniture(roomName, furnitureProps) {
   return {
     type: ADD_FURNITURE,
-    furnitureName,
-    roomName
+    roomName,
+    furnitureProps,
   };
 }
 

--- a/src/rooms/actions/rooms.action.js
+++ b/src/rooms/actions/rooms.action.js
@@ -15,7 +15,6 @@ export function addRoomFromDb(room) {
 }
 
 export function addRoom(room) {
-  console.log('room data sent to addRoom fn: ', room);
   const roomName = room.roomName;
   room = {};
   room[roomName] = { furniture: {} };

--- a/src/rooms/reducers/rooms.reducer.js
+++ b/src/rooms/reducers/rooms.reducer.js
@@ -14,9 +14,14 @@ const roomsReducer = (state = {}, action) => {
       }
       return Object.assign(_.cloneDeep(state), action.room);
     case ADD_FURNITURE:
+      if (!action.roomName) {
+        return state;
+      }
       newState = _.clone(state);
-      const furnitureName = Object.keys(action.furnitureName)[0];
-      newState[action.roomName][furnitureName] = action.furnitureName[furnitureName];
+      const roomName = action.roomName;
+      const furnitureName = action.furnitureProps.itemName;
+      delete action.furnitureProps.itemName;
+      newState[roomName].furniture[furnitureName] = action.furnitureProps;
       return newState;
     case DELETE_FURNITURE:
       newState = _.clone(state);
@@ -33,3 +38,22 @@ const roomsReducer = (state = {}, action) => {
 };
 
 export default roomsReducer;
+
+/*
+ deliveryDate
+ :
+ undefined
+ description
+ :
+ undefined
+ itemName
+ :
+ "aoe"
+ price
+ :
+ "oae"
+
+ url
+ :
+ undefined
+ */


### PR DESCRIPTION
This allows the user to add furniture to the correct room. It only works if they get to the furniture page by selecting a room from the homepage. If you start from the /furniture route, there's no roomSelected property, so no furniture is added.
