### PR TITLE
Refactor: Change furniture list to reveal cards

### DIFF
--- a/src/cardList/components/FList.js
+++ b/src/cardList/components/FList.js
@@ -1,0 +1,48 @@
+import React, { Component } from 'react';
+import ListItem from './ListItem';
+import AddItemButton from './AddItemButton';
+import {Row, Col, Table, Card, CardTitle} from 'react-materialize';
+import './cardList.css';
+
+class FList extends Component {
+  render() {
+    const listNames = Object.keys(this.props.list);
+    return (
+      <div className="CardList">
+        {listNames.map((itemName) => {
+          return (
+            <div l={3} s={12}>
+              <Card header={<CardTitle reveal image={"http://blog.wanken.com/wp-content/uploads/2010/10/Eames-Lounge-Chair-and-Ottoman.jpeg"} waves='light'/>}
+                title={itemName}
+                reveal={
+                  <Table>
+                    <tbody>
+                      <tr>
+                        <td>Name</td>
+                        <td>Price</td>
+                        <td>URL</td>
+                      </tr>
+                      <tr>
+                        <td>Description</td>
+                        <td>Quantity</td>
+                        <td>Delivery Date</td>
+                      </tr>
+                      <tr>
+                        <td>Notes</td>
+                      </tr>
+                    </tbody>
+                  </Table>
+
+                }>
+                <p>Price <a href="#">This is a link</a></p>
+              </Card>
+            </div>
+          );
+        })}
+        <AddItemButton view={this.props.view === 'rooms' ? 'room' : 'furniture'} />
+      </div>
+    );
+  }
+}
+
+export default FList;

--- a/src/furniture/containers/furnitureList.container.js
+++ b/src/furniture/containers/furnitureList.container.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect} from 'react-redux';
-import CardList from '../../cardlist/components/CardList';
+import FList from '../../cardlist/components/FList';
+import {Row, Col} from 'react-materialize';
 import { bindActionCreators } from 'redux';
 
 
@@ -14,14 +15,18 @@ class FurnitureList extends Component {
     }
     //const furniture = this.state.furniture || ['chair', 'swing']
     return (
-      <div>
+      <Row>
+      <div s={12} l={6}>
         <h3>Current Rooms Furniture</h3>
-        <CardList
+        
+
+        <FList
           list={ furniture }
           intro={ intro }
           view="furniture"
         />
       </div>
+      </Row>
     );
   }
 }


### PR DESCRIPTION
-Refactor Furniture List to use reveal cards instead of reusable component

Reviewed By: Ben
