### PR TITLE
feat: Add ability to mark projects private/public

### DIFF
--- a/src/BudgetView/components/budgetGraph.jsx
+++ b/src/BudgetView/components/budgetGraph.jsx
@@ -28,8 +28,7 @@ class BudgetGraph extends Component {
     const calcBudget = budgetHelper.calculateBudget;
     const toTitleCase = budgetHelper.toTitleCase;
     if(Object.keys(rooms).length !== 0) {
-      
-      genData = budgetHelper.generateData(rooms, budget);
+      genData = budgetHelper.generateData(rooms);
     }
 
     return(
@@ -59,8 +58,7 @@ class BudgetGraph extends Component {
               let roomCost = calcBudget(roomName, rooms);
               this.totalCost += roomCost;
               return (
-                <tr 
-                key={id}>
+                <tr key={id}>
                   <th>{ budgetHelper.toTitleCase(roomName) }</th>
                   <th>{ roomCost } </th>
                 </tr>
@@ -75,6 +73,3 @@ class BudgetGraph extends Component {
 } 
 
 export default BudgetGraph;
-              // console.log(selection)
-              // console.log(selection.data)
-              // console.log(selection.data.key)

--- a/src/app/App.css
+++ b/src/app/App.css
@@ -32,6 +32,14 @@ body {
 
 }
 
+.RoomListHeader {
+  height: 45px;
+}
+
+.RoomListHeader label, .RoomListHeader input {
+  margin: 15px 0;
+}
+
 .ListItem {
   background: rgba(0, 0, 0, 0.4);
 }

--- a/src/app/header.component.jsx
+++ b/src/app/header.component.jsx
@@ -12,7 +12,8 @@ class Header extends Component {
   }
 
   changePublicStatus() {
-    this.props.makePublic_Private(this.props.shared);
+    const newPublicStatus = !this.props.public;
+    this.props.makePublic_Private(newPublicStatus);
   }
 
   signInSignOut() {
@@ -59,7 +60,6 @@ class Header extends Component {
   render() {
     return (
       <Navbar brand='Nailed-It' right className="grey darken-3">
-        <NavItem>{this.makePublic()}</NavItem>
         <NavItem className={ 'nav-item' + this.activeIfRoom('public') }><Link to={ 'public' }>List of public projects</Link></NavItem>
         <NavItem className={ 'nav-item' + this.activeIfRoom('room') }><Link to={ 'room' }>My Rooms</Link></NavItem>
         <NavItem onClick={()=>this.signInSignOut()}>{this.props.authenticated ? 'Sign Out' : 'Sign In'}</NavItem>
@@ -68,8 +68,12 @@ class Header extends Component {
   }
 }
 
-function mapStateToProps({ shared, authenticated, route }) {
-  return { shared, authenticated, route };
+function mapStateToProps(state) {
+  return {
+    'public': state.public, // apparently public is a reserved word, so I'm structuring this function this way
+    authenticated: state.authenticated,
+    route: state.route
+};
 }
 
 function mapDispatchToProps(dispatch) {

--- a/src/databaseAPI.js
+++ b/src/databaseAPI.js
@@ -22,6 +22,10 @@ var metadata = {
 
 
 const databaseAPI = {
+  toggleProjectPrivacy(newPublicStatus) {
+    console.log('about to request the database change the public sattus of the project: ', newPublicStatus);
+    database.ref('iGEKbLdXzHORTksYSB21JSd8cqA3/public').set(newPublicStatus);
+  },
 
   uploadPhoto(file) {
     // Per the comment on the assignment of storageRef, if this code is run by our tests,

--- a/src/public_view/containers/publicProjectList.container.jsx
+++ b/src/public_view/containers/publicProjectList.container.jsx
@@ -13,6 +13,14 @@ export default class ProjectList extends Component {
   }
 
   render() {
+    const projectNames = Object.keys(this.props.projects);
+    const publicProjects = projectNames.reduce((projectsObj, projectName) => {
+      if (this.props.projects[projectName].public) {
+        projectsObj[projectName] = this.props.projects[projectName];
+      }
+      return projectsObj;
+    }, {});
+    console.log('publicProjects: ', publicProjects);
     return (
       <Row>
       <h3> List of Public Projects</h3>
@@ -21,7 +29,7 @@ export default class ProjectList extends Component {
             <CardList
               clickHandler={this.props.selectProject}
               intro={this.props.projectSelected}
-              lists={this.props.projects}
+              lists={publicProjects}
               view="projects"
             />
           </div>

--- a/src/public_view/reducers/project.reducer.js
+++ b/src/public_view/reducers/project.reducer.js
@@ -1,17 +1,26 @@
 import { ADD_PROJECT } from '../actions/public.action';
+import { MAKE_PUBLIC_PRIVATE } from '../../rooms/actions/rooms.action';
 import _ from 'lodash';
 
 const projectReducer = (state = {}, action) => {
   switch (action.type) {
     case ADD_PROJECT:
-      action.project = action.payload.val() || {};
-      action.publicProjects = {};
-      for (var key in action.project) {
-        if (action.project[key].public === true) {
-          action.publicProjects[key] = action.project[key];
-        }
+      //action.project = action.payload.val() || {};
+      //action.publicProjects = {};
+      //for (var key in action.project) {
+      //  if (action.project[key].public === true) {
+      //    action.publicProjects[key] = action.project[key];
+      //  }
+      //}
+      //return Object.assign(_.cloneDeep(state), action.publicProjects);
+      return action.payload.val();
+    case MAKE_PUBLIC_PRIVATE:
+      const newState = _.cloneDeep(state);
+      console.log('newState: ', newState);
+      if (newState.iGEKbLdXzHORTksYSB21JSd8cqA3) {
+        newState.iGEKbLdXzHORTksYSB21JSd8cqA3.public = action.newPublicStatus;
       }
-      return Object.assign(_.cloneDeep(state), action.publicProjects);
+      return newState;
     default:
       return state;
   }

--- a/src/rooms/actions/rooms.action.js
+++ b/src/rooms/actions/rooms.action.js
@@ -56,10 +56,13 @@ export function updateRoomDetails(oldRoomName, roomContents, newRoomDetails, ign
 }
 
 export const MAKE_PUBLIC_PRIVATE = 'MAKE_PUBLIC_PRIVATE';
-export function makePublic_Private(shared) {
+export function makePublic_Private(newPublicStatus) {
+  // Update the public status of the project in the database
+  databaseAPI.toggleProjectPrivacy(newPublicStatus);
+
   return {
     type: MAKE_PUBLIC_PRIVATE,
-    shared,
+    newPublicStatus,
   };
 }
 

--- a/src/rooms/containers/roomsList.container.jsx
+++ b/src/rooms/containers/roomsList.container.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import CardList from '../components/cardList.component.jsx';
 import { getRooms, selectRoom,  makePublic_Private, addPhoto } from '../actions/rooms.action';
 import { bindActionCreators } from 'redux';
-import { Row, Col, Button } from 'react-materialize';
+import { Row, Col, Button, Input } from 'react-materialize';
 import BudgetView from '../../BudgetView/containers/budgetView.container';
 import { changeRoute } from '../../routing/actions/routing.action';
 import Dropzone from 'react-dropzone';
@@ -19,21 +19,24 @@ export default class RoomsList extends Component {
     }
   }
 
-  changePublicStatus() {
-    this.props.makePublic_Private(this.props.shared);
-  }
   onDrop(files) {
     // console.log('Received files: ', files);
     this.props.addPhoto(files);
   }
 
   render() {
+    const currentProject = this.props.projects.iGEKbLdXzHORTksYSB21JSd8cqA3;
+    const currentPublicStatus = currentProject && this.props.projects.iGEKbLdXzHORTksYSB21JSd8cqA3.public;
     return (
       <div>
         <Row>
           <Col s={12} m={6} l={6}>
             <div style={{"overflowY":"scroll"}}>
-              <span className="RoomListHeader"></span>
+              <div className="RoomListHeader">
+                <Input name='public' type='checkbox' value='Public' checked={currentPublicStatus}
+                       label='Make this project public'
+                       onChange={() => this.props.makePublic_Private(!currentPublicStatus)}/>
+              </div>
               <CardList
                 clickHandler={this.props.selectRoom}
                 addPhoto={this.onDrop}
@@ -57,12 +60,12 @@ export default class RoomsList extends Component {
   }
 }
 
-function mapStateToProps({ rooms, roomSelected, shared, route }) {
-  return { rooms, roomSelected, shared, route };
+function mapStateToProps({ projects, rooms, roomSelected, route }) {
+  return { projects, rooms, roomSelected, route };
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ getRooms, selectRoom, addPhoto, changeRoute }, dispatch);
+  return bindActionCreators({ getRooms, selectRoom, addPhoto, changeRoute, makePublic_Private }, dispatch);
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(RoomsList);

--- a/src/rooms/reducers/shareRooms.reducer.js
+++ b/src/rooms/reducers/shareRooms.reducer.js
@@ -1,9 +1,13 @@
+// NOTE: THIS ISN'T CURRENTLY USED ANYWHERE. INSTEAD, THE REDUCER
+// FOR TOGGLING A PROJECT'S PRIVATE STATUS IS IN THE
+// project.reducer.js FILE.
+
 import { MAKE_PUBLIC_PRIVATE } from '../actions/rooms.action';
 
 const shareRooms = (state = false, action) => {
   switch (action.type) {
     case MAKE_PUBLIC_PRIVATE:
-      return !action.shared;
+      return action.newPublicStatus;
     default:
       return state;
   }

--- a/src/root.reducer.js
+++ b/src/root.reducer.js
@@ -3,7 +3,7 @@ import roomsReducer from './rooms/reducers/rooms.reducer';
 import selectRoomReducer from './rooms/reducers/selectRoom.reducer';
 import { reducer as formReducer} from 'redux-form';
 import budgetReducer from './BudgetView/reducers/BudgetView.reducer';
-import publicReducer from './public_view/reducers/project.reducer';
+import projectReducer from './public_view/reducers/project.reducer';
 import shareRooms from './rooms/reducers/shareRooms.reducer';
 import authenticationReducer from './signup_signin/reducers/authentication.reducer';
 import router from './routing/reducers/routing.reducer';
@@ -13,8 +13,8 @@ const rootReducer = combineReducers({
   roomSelected: selectRoomReducer,
   form: formReducer,
   budget: budgetReducer,
-  projects: publicReducer,
-  shared: shareRooms,
+  projects: projectReducer,
+  //public: shareRooms,
   authenticated: authenticationReducer,
   route: router
 });


### PR DESCRIPTION
We kind of had this feature before, but we didn't persist anything to the database. Now the checkbox updates the database and the redux state.

I also moved the button into the RoomsList, out of the navbar, where it was a bit out of place.

The checkbox reflects the current public/private status of the project.
