### PR TITLE
fix(routing): Fix bug causing url to accumulate "furniture" instances

### DIFF
--- a/src/app/header.component.jsx
+++ b/src/app/header.component.jsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router';
 class Header extends Component {
   static contextTypes = {
     router: React.PropTypes.object
-  }
+  };
 
   changePublicStatus() {
     const newPublicStatus = !this.props.public;
@@ -60,8 +60,8 @@ class Header extends Component {
   render() {
     return (
       <Navbar brand='Nailed-It' right className="grey darken-3">
-        <NavItem className={ 'nav-item' + this.activeIfRoom('public') }><Link to={ 'public' }>List of public projects</Link></NavItem>
-        <NavItem className={ 'nav-item' + this.activeIfRoom('room') }><Link to={ 'room' }>My Rooms</Link></NavItem>
+        <NavItem className={ 'nav-item' + this.activeIfRoom('public') }><Link to={ '/public' }>List of public projects</Link></NavItem>
+        <NavItem className={ 'nav-item' + this.activeIfRoom('room') }><Link to={ '/room' }>My Rooms</Link></NavItem>
         <NavItem onClick={()=>this.signInSignOut()}>{this.props.authenticated ? 'Sign Out' : 'Sign In'}</NavItem>
       </Navbar>
     );
@@ -73,7 +73,7 @@ function mapStateToProps(state) {
     'public': state.public, // apparently public is a reserved word, so I'm structuring this function this way
     authenticated: state.authenticated,
     route: state.route
-};
+  };
 }
 
 function mapDispatchToProps(dispatch) {
@@ -81,4 +81,3 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Header);
-       

--- a/src/databaseAPI.js
+++ b/src/databaseAPI.js
@@ -23,7 +23,6 @@ var metadata = {
 
 const databaseAPI = {
   toggleProjectPrivacy(newPublicStatus) {
-    console.log('about to request the database change the public sattus of the project: ', newPublicStatus);
     database.ref('iGEKbLdXzHORTksYSB21JSd8cqA3/public').set(newPublicStatus);
   },
 
@@ -86,7 +85,6 @@ const databaseAPI = {
 
   updateRoom(oldRoomName, newRoomName, clonedRoom) {
     return database.ref('iGEKbLdXzHORTksYSB21JSd8cqA3/rooms/' + newRoomName).set(clonedRoom).then((snapshot) => {
-      console.log('snapshot returned by update room: ', snapshot);
       database.ref('iGEKbLdXzHORTksYSB21JSd8cqA3/rooms/' + oldRoomName).remove();
     });
   },

--- a/src/public_view/containers/publicProjectList.container.jsx
+++ b/src/public_view/containers/publicProjectList.container.jsx
@@ -3,7 +3,7 @@ import { connect} from 'react-redux';
 import CardList from '../components/cardList.component';
 import { addProjectFromDb, selectProject } from '../actions/public.action';
 import { bindActionCreators } from 'redux';
-import { Row, Col, Modal, Button } from 'react-materialize';
+import { Row, Col } from 'react-materialize';
 import { changeRoute } from '../../routing/actions/routing.action';
 
 export default class ProjectList extends Component {
@@ -20,7 +20,6 @@ export default class ProjectList extends Component {
       }
       return projectsObj;
     }, {});
-    console.log('publicProjects: ', publicProjects);
     return (
       <Row>
       <h3> List of Public Projects</h3>

--- a/src/public_view/reducers/project.reducer.js
+++ b/src/public_view/reducers/project.reducer.js
@@ -16,7 +16,6 @@ const projectReducer = (state = {}, action) => {
       return action.payload.val();
     case MAKE_PUBLIC_PRIVATE:
       const newState = _.cloneDeep(state);
-      console.log('newState: ', newState);
       if (newState.iGEKbLdXzHORTksYSB21JSd8cqA3) {
         newState.iGEKbLdXzHORTksYSB21JSd8cqA3.public = action.newPublicStatus;
       }

--- a/src/root.reducer.js
+++ b/src/root.reducer.js
@@ -4,7 +4,7 @@ import selectRoomReducer from './rooms/reducers/selectRoom.reducer';
 import { reducer as formReducer} from 'redux-form';
 import budgetReducer from './BudgetView/reducers/BudgetView.reducer';
 import projectReducer from './public_view/reducers/project.reducer';
-import shareRooms from './rooms/reducers/shareRooms.reducer';
+//import shareRooms from './rooms/reducers/shareRooms.reducer';
 import authenticationReducer from './signup_signin/reducers/authentication.reducer';
 import router from './routing/reducers/routing.reducer';
 


### PR DESCRIPTION
When clicking back and forth between My Rooms and an individual room, the url used to accumulate instances of '/furniture'. So a url might look like /furniture/furniture/furniture/rooms.

This fixes the routing by making the Links direct to absolute paths, rather than relative ones.
