### PR TITLE
feat: Use react routing for Nailed-It header link

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -40,6 +40,10 @@ body {
   margin: 15px 0;
 }
 
+.brand {
+  font-size: 2rem;
+}
+
 .ListItem {
   background: rgba(0, 0, 0, 0.4);
 }

--- a/src/app/header.component.jsx
+++ b/src/app/header.component.jsx
@@ -59,10 +59,11 @@ class Header extends Component {
 
   render() {
     return (
-      <Navbar brand='Nailed-It' right className="grey darken-3">
-        <NavItem className={ 'nav-item' + this.activeIfRoom('public') }><Link to={ '/public' }>List of public projects</Link></NavItem>
-        <NavItem className={ 'nav-item' + this.activeIfRoom('room') }><Link to={ '/room' }>My Rooms</Link></NavItem>
-        <NavItem onClick={()=>this.signInSignOut()}>{this.props.authenticated ? 'Sign Out' : 'Sign In'}</NavItem>
+      <Navbar className="grey darken-3">
+        <NavItem><Link to="/room"><span id="brand">Nailed-It</span></Link></NavItem>
+        <NavItem className="left" onClick={()=>this.signInSignOut()}>{this.props.authenticated ? 'Sign Out' : 'Sign In'}</NavItem>
+        <NavItem className={ 'right nav-item' + this.activeIfRoom('public') }><Link to={ '/public' }>List of public projects</Link></NavItem>
+        <NavItem className={ 'right nav-item' + this.activeIfRoom('room') }><Link to={ '/room' }>My Rooms</Link></NavItem>
       </Navbar>
     );
   }


### PR DESCRIPTION
This link used to cause a refresh of the page, and take us back to the '/' route. Now it uses react routing and reroutes to the '/room' route. The page doesn't refresh.

Reviewed by Josh
